### PR TITLE
Quitar notas por todos los usuarios

### DIFF
--- a/src/db/MongoUtils.js
+++ b/src/db/MongoUtils.js
@@ -85,6 +85,7 @@ function MongoUtils() {
                 .finally(() => client.close());
         });
 
+    //Todos los usuarios pueden borrar notas de otras personas. Es necesario incluir alguna autenticación, ya que hace a la app un poco díficil de usar :(
     mu.deleteNote = (id) =>
         mu.connect().then((client) => {
             const noteCol = client.db(dbTaskMate).collection(noteCollection);


### PR DESCRIPTION
Se podría borrar quitar notas por todos los usuarios para que solo se puedan crear y no borrar por los otros usuarios.